### PR TITLE
Add slew rate limiter to XRPMotor speed to minimize brown-outs

### DIFF
--- a/src/main/java/frc/robot/subsystems/shooter/ShooterIOXrp.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterIOXrp.java
@@ -1,9 +1,11 @@
 package frc.robot.subsystems.shooter;
 
+import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.wpilibj.xrp.XRPMotor;
 
 public class ShooterIOXrp implements ShooterIO {
   private final XRPMotor motor;
+  private SlewRateLimiter filter = new SlewRateLimiter(4.0);
 
   public ShooterIOXrp(int deviceNum) {
     motor = new XRPMotor(deviceNum);
@@ -14,6 +16,7 @@ public class ShooterIOXrp implements ShooterIO {
   }
 
   public void setSpeed(double speed) {
+    speed = filter.calculate(speed);
     motor.set(speed);
   }
 }


### PR DESCRIPTION
I finally got around to testing the DC motor, also.  I still got brown outs if I set the motor speed from 0 --> 1.0 immediately.  I added a slew rate limiter to minimize brown-outs by ramping the desired speed/up down to the target speed.